### PR TITLE
Fix default font ratio for expressions

### DIFF
--- a/src/plugins/compact-view/compact.less
+++ b/src/plugins/compact-view/compact.less
@@ -12,9 +12,11 @@
       max(var(--bracket-font-size-factor), var(--minimum-font-size))
     );
   }
-  .dcg-main,
+  .dcg-main {
+    font-size: calc(1.1 * (16 / 18) * var(--math-font-size));
+  }
   .dcg-evaluation-container {
-    font-size: var(--math-font-size);
+    font-size: calc((16 / 18) * var(--math-font-size));
   }
 
   &.compact-view-no-separating-lines {


### PR DESCRIPTION
The deafult font size for expressions is 110% above the regular font size. That means that evaluation containers have a font size of 16 px while expressions have a font size of rougly 17.6 px. Default math font size now reflects the actual default.